### PR TITLE
fix: handle case when backspace is ^H, not 0x7F

### DIFF
--- a/miniline.go
+++ b/miniline.go
@@ -174,6 +174,11 @@ func (lr *lineReader) readLine() error {
 				return ErrInterrupted
 			case 4, 13: // ^D, ^M (which is also the return key)
 				return nil
+			case 8: // ^H
+				if err := lr.backspace(); err != nil {
+					return err
+				}
+				continue
 			case 26: // ^Z
 				lr.tty.exitRaw()
 				syscall.Kill(0, syscall.SIGSTOP)


### PR DESCRIPTION
In a pure docker ubuntu 14.04 image, the backspace is being read as ^H (code: 8) instead of 0x7F. This fix adds support for such cases.